### PR TITLE
Fix temporarily : broken work

### DIFF
--- a/autoload/ctrlp/tagbar.vim
+++ b/autoload/ctrlp/tagbar.vim
@@ -53,10 +53,6 @@ function! ctrlp#tagbar#init()
   catch
   endtry
 
-  if empty(tag_list)
-    return ''
-  endif
-
   call filter(tag_list, '!empty(v:val)')
   return tag_list
 endfunction
@@ -78,11 +74,9 @@ func! ctrlp#tagbar#accept(mode, str)
   catch
   endtry
 
-  if empty(taginfo)
-    return 
+  if !empty(taginfo)
+    execute taginfo[0].fields.line
   endif
-
-  execute taginfo[0].fields.line
 endfunc
 
 

--- a/autoload/ctrlp/tagbar.vim
+++ b/autoload/ctrlp/tagbar.vim
@@ -24,13 +24,13 @@ let g:loaded_ctrlp_tagbar = 1
 "                      |     `- match full line like file/dir path
 "                      `- match full line
 let s:tagbar_var = {
-      \ 'init': 'ctrlp#tagbar#init(s:crfile)',
+      \ 'init':   'ctrlp#tagbar#init()',
       \ 'accept': 'ctrlp#tagbar#accept',
-      \ 'lname': 'tagbar',
-      \ 'sname': 'tbar',
-      \ 'type': 'line',
-      \ 'sort'  : 0,
-      \ 'nolim' : 1,
+      \ 'lname':  'tagbar',
+      \ 'sname':  'tbar',
+      \ 'type':   'line',
+      \ 'sort':   0,
+      \ 'nolim':  1,
       \ }
 
 
@@ -45,9 +45,19 @@ endif
 " Provide a list of strings to search in
 "
 " Return: command
-function! ctrlp#tagbar#init(fname)
-  let tag_list = tagbar#currenttags(a:fname)
-  let tag_list = filter(tag_list, '!empty(v:val)')
+function! ctrlp#tagbar#init()
+  let tag_list = []
+  try
+    let tagdict = tagbar#state#get_current_file(0)._tagdict
+    let tag_list = keys(tagdict)
+  catch
+  endtry
+
+  if empty(tag_list)
+    return ''
+  endif
+
+  call filter(tag_list, '!empty(v:val)')
   return tag_list
 endfunction
 
@@ -60,7 +70,19 @@ endfunction
 "  a:str    the selected string
 func! ctrlp#tagbar#accept(mode, str)
   call ctrlp#exit()
-  call tagbar#jumptotag(a:str)
+
+  let taginfo = []
+  try
+    let tagsinfo = tagbar#state#get_current_file(0)
+    let taginfo = tagsinfo.getTagsByName(a:str)
+  catch
+  endtry
+
+  if empty(taginfo)
+    return 
+  endif
+
+  execute taginfo[0].fields.line
 endfunc
 
 

--- a/autoload/ctrlp/tagbar.vim
+++ b/autoload/ctrlp/tagbar.vim
@@ -5,9 +5,9 @@
 
 " Change the name of the g:loaded_ variable to make it unique
 if ( exists('g:loaded_ctrlp_tagbar') && g:loaded_ctrlp_tagbar )
-	\ || !exists(':TagbarToggle')
-	\ || v:version < 700 || &cp
-	finish
+      \ || !exists(':TagbarToggle')
+      \ || v:version < 700 || &cp
+  finish
 endif
 let g:loaded_ctrlp_tagbar = 1
 
@@ -24,21 +24,21 @@ let g:loaded_ctrlp_tagbar = 1
 "                      |     `- match full line like file/dir path
 "                      `- match full line
 let s:tagbar_var = {
-	\ 'init': 'ctrlp#tagbar#init(s:crfile)',
-	\ 'accept': 'ctrlp#tagbar#accept',
-	\ 'lname': 'tagbar',
-	\ 'sname': 'tbar',
-	\ 'type': 'line',
-	\ 'sort'  : 0,
-	\ 'nolim' : 1,
-	\ }
+      \ 'init': 'ctrlp#tagbar#init(s:crfile)',
+      \ 'accept': 'ctrlp#tagbar#accept',
+      \ 'lname': 'tagbar',
+      \ 'sname': 'tbar',
+      \ 'type': 'line',
+      \ 'sort'  : 0,
+      \ 'nolim' : 1,
+      \ }
 
 
 " Append s:tagbar_var to g:ctrlp_ext_vars
 if exists('g:ctrlp_ext_vars') && !empty(g:ctrlp_ext_vars)
-	let g:ctrlp_ext_vars = add(g:ctrlp_ext_vars, s:tagbar_var)
+  let g:ctrlp_ext_vars = add(g:ctrlp_ext_vars, s:tagbar_var)
 else
-	let g:ctrlp_ext_vars = [s:tagbar_var]
+  let g:ctrlp_ext_vars = [s:tagbar_var]
 endif
 
 
@@ -46,7 +46,7 @@ endif
 "
 " Return: command
 function! ctrlp#tagbar#init(fname)
-	let tag_list = tagbar#currenttags(a:fname)
+  let tag_list = tagbar#currenttags(a:fname)
   let tag_list = filter(tag_list, '!empty(v:val)')
   return tag_list
 endfunction
@@ -60,7 +60,7 @@ endfunction
 "  a:str    the selected string
 func! ctrlp#tagbar#accept(mode, str)
   call ctrlp#exit()
-	call tagbar#jumptotag(a:str)
+  call tagbar#jumptotag(a:str)
 endfunc
 
 


### PR DESCRIPTION
Tagbar public API is missing.

* tagbar#currenttags : tag list at target file
* tagbar#jumptotag : jump to target tag

It is corrected by using the internal dictionary structure temporarily.
It need to request a stable open API from tagbar again and re-fix it.

* tag list (target file or current file)
* tag info : line or direct jump